### PR TITLE
Add #modding-showcase channel features

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -6,8 +6,11 @@ with open(CONFIG_PATH) as config_file:
 
 DISCORD_KEY = cfg['discord']
 ART_CHANS = cfg['channels']['listening']
+MOD_CHANS = cfg['channels']['selfcurated']
 VERIFY_CHAN = cfg['channels']['verify']
 GALLERY_CHAN = cfg['channels']['gallery']
+SHOWCASE_CHAN = cfg['channels']['showcase']
+SHOWCASE_ROLES = cfg['roles']['showcase']
 
 intents = discord.Intents.default()
 client = discord.Client(intents=intents)

--- a/src/main.py
+++ b/src/main.py
@@ -36,12 +36,16 @@ async def on_reaction_add(reaction: discord.Reaction, user: discord.User):
 
     # User reactions to posts in self-curated channel
     elif reaction.message.channel.id in MOD_CHANS:
+        # Ignore reactions from users other than the message author
+        if user != reaction.message.author:
+            return
+
         # Ignore reactions from users without any of the required roles
         if len(SHOWCASE_ROLES) == 0 or len([r for r in user.roles if r.id in SHOWCASE_ROLES]) == 0:
             return
 
-        # Ignore reactions from users other than the message author
-        if user != reaction.message.author:
+        # Ignore emoji reactions unusable by the bot
+        if not reaction.emoji.is_usable():
             return
 
         # Publish self-curated posts
@@ -76,8 +80,8 @@ async def publish_art(message: discord.Message):
     gallery = client.get_channel(id=GALLERY_CHAN)
     user = message.mentions[0]
     title = f"Some amazing art by {user}"
-    split = message.split('\n')
-    text = split[1:-2]
+    split = message.content.split('\n')
+    text = split[-2]
     embed = discord.Embed(title=title, type="rich", color=user.color, description=text)
     embed.set_image(url=split[-1])
     await send_embed(channel=gallery, embed=embed, message=message)
@@ -85,7 +89,7 @@ async def publish_art(message: discord.Message):
 async def publish_mod(message: discord.Message, reaction: discord.Reaction):
     channel = client.get_channel(id=SHOWCASE_CHAN)
     user = message.author
-    title = f"{reaction.emoji}   posted in #{str(message.channel)}"
+    title = f"{reaction.emoji} posted in #{str(message.channel)}"
     text = f"{message.content}"
     embed = discord.Embed(title=title, description=text, type="rich", color=user.color)
 

--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,9 @@
 # https://github.com/aquova/leah
 
 import discord
-from config import client, DISCORD_KEY, ART_CHANS, VERIFY_CHAN, GALLERY_CHAN
+from config import client, DISCORD_KEY,\
+    ART_CHANS, MOD_CHANS, VERIFY_CHAN, GALLERY_CHAN, SHOWCASE_CHAN,\
+    SHOWCASE_ROLES
 
 class Leah:
     def __init__(self):
@@ -18,28 +20,97 @@ async def on_ready():
     print(client.user.id)
 
 @client.event
-async def on_reaction_add(reaction, user):
-    if reaction.message.channel.id != VERIFY_CHAN or client.user != reaction.message.author:
-        return
+async def on_reaction_add(reaction: discord.Reaction, user: discord.User):
+    # Ignore messages that have been handled previously
     if reaction.message.id in leah.posted:
         return
-    leah.posted.add(reaction.message.id)
-    txt = reaction.message.content.split('\n')
-    other = reaction.message.mentions[0]
-    embed = discord.Embed(title=f"Some amazing art by {str(other)}", type="rich", color=other.color, description=txt[-2])
-    embed.set_image(url=txt[-1])
-    gallery = client.get_channel(GALLERY_CHAN)
-    await gallery.send(embed=embed)
+
+    # Staff reactions to verification channel posts by this client
+    if reaction.message.channel.id == VERIFY_CHAN:
+        # Ignore reactions to posts not by this client in verification channel
+        if client.user != reaction.message.author:
+            return
+
+        # Publish verified posts to gallery channel
+        await publish_art(message=reaction.message)
+
+    # User reactions to posts in self-curated channel
+    elif reaction.message.channel.id in MOD_CHANS:
+        # Ignore reactions from users without any of the required roles
+        if len(SHOWCASE_ROLES) == 0 or len([r for r in user.roles if r.id in SHOWCASE_ROLES]) == 0:
+            return
+
+        # Ignore reactions from users other than the message author
+        if user != reaction.message.author:
+            return
+
+        # Publish self-curated posts
+        await reaction.message.add_reaction(emoji=reaction.emoji)
+        await publish_mod(message=reaction.message, reaction=reaction)
+
+    # User reactions to posts in showcase channel
+    elif reaction.message.channel.id == SHOWCASE_CHAN:
+        # Ignore reactions from users other than the message author
+        if user != reaction.message.author:
+            return
+
+        # Remove bulletin posts
+        await reaction.message.delete()
 
 @client.event
-async def on_message(message):
+async def on_message(message: discord.Message):
     # Ignore all bots
     if message.author.bot:
         return
 
+    # Send posts from creative channel to verification channel
     if message.channel.id in ART_CHANS:
-        verify = client.get_channel(VERIFY_CHAN)
-        for img in message.attachments:
-            await verify.send(f"<@{message.author.id}> has posted:\n{message.content}\n{img.url}")
+        await verify_art(message=message)
+
+async def verify_art(message: discord.Message):
+    verify = client.get_channel(id=VERIFY_CHAN)
+    for img in message.attachments:
+        await verify.send(f"<@{message.author.id}> has posted:\n{message.content}\n{img.url}")
+
+async def publish_art(message: discord.Message):
+    gallery = client.get_channel(id=GALLERY_CHAN)
+    user = message.mentions[0]
+    title = f"Some amazing art by {user}"
+    split = message.split('\n')
+    text = split[1:-2]
+    embed = discord.Embed(title=title, type="rich", color=user.color, description=text)
+    embed.set_image(url=split[-1])
+    await send_embed(channel=gallery, embed=embed, message=message)
+
+async def publish_mod(message: discord.Message, reaction: discord.Reaction):
+    channel = client.get_channel(id=SHOWCASE_CHAN)
+    user = message.author
+    title = f"{reaction.emoji}   posted in #{str(message.channel)}"
+    text = f"{message.content}"
+    embed = discord.Embed(title=title, description=text, type="rich", color=user.color)
+
+    # Include original embedded content
+    url = None
+    if len(message.embeds) > 0:
+        e = message.embeds[0]
+        url = e.image.proxy_url
+        if url is discord.embeds.EmptyEmbed:
+            url = e.thumbnail.proxy_url
+    else:
+        if len(message.attachments) > 0:
+            url = message.attachments[0].url
+    if url is not None and url is not discord.embeds.EmptyEmbed:
+        embed.set_image(url=url)
+
+    # Fill in embed info with original message context
+    embed.url = message.jump_url
+    embed.set_author(name=user.nick, url=embed.url, icon_url=user.avatar_url)
+
+    await send_embed(channel=channel, embed=embed, message=message)
+
+async def send_embed(channel: discord.TextChannel, embed: discord.Embed, message: discord.Message):
+    leah.posted.add(message.id)
+    await channel.send(embed=embed)
+
 
 client.run(DISCORD_KEY)


### PR DESCRIPTION
Add support for self-curated submission and gallery channels.

## config.py
Add fields:
+ `MOD_CHANS` - `set<int>` - List of channel IDs for self-curated-channels.
+ `SHOWCASE_CHAN` - `int` - Channel ID for showcase channel for client to repost messages in MOD_CHANS.
+ `SHOWCASE_ROLES` - `set<int>` - List of role IDs capable of making submissions in MOD_CHANS.

## main.py
Add methods:
+ `verify_art(message)` - Replace message reposting from ART_CHANS to VERIFY_CHAN.
+ `publish_art(message)` - Replace staff reaction handling from VERIFY_CHAN to GALLERY_CHAN.
+ `publish_mod(message, reaction)` - Read reacted posts in MOD_CHANS and repost directly to SHOWCASE_CHAN with original embedded content.