### PR TITLE
Fix bug preventing self-removals from showcase channel.

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,7 @@ import discord
 from config import client, DISCORD_KEY,\
     ART_CHANS, MOD_CHANS, VERIFY_CHAN, GALLERY_CHAN, SHOWCASE_CHAN,\
     SHOWCASE_ROLES
+from typing import Optional
 
 class Leah:
     def __init__(self):
@@ -112,7 +113,7 @@ async def send_embed(channel: discord.TextChannel, embed: discord.Embed, message
     leah.posted.add(message.id)
     await channel.send(embed=embed)
 
-async def get_original_author(showcase_message: discord.Message):
+async def get_original_author(showcase_message: discord.Message) -> Optional[discord.Member]:
     split_url = showcase_message.embeds[0].url.split('/')
     original_channel = showcase_message.guild.get_channel(int(split_url[-2]))
     try:

--- a/src/main.py
+++ b/src/main.py
@@ -51,7 +51,7 @@ async def on_reaction_add(reaction: discord.Reaction, user: discord.User):
     # User reactions to posts in showcase channel
     elif reaction.message.channel.id == SHOWCASE_CHAN:
         # Ignore reactions from users other than the message author
-        if user != reaction.message.author:
+        if user != await get_original_author(reaction.message):
             return
 
         # Remove bulletin posts
@@ -112,5 +112,13 @@ async def send_embed(channel: discord.TextChannel, embed: discord.Embed, message
     leah.posted.add(message.id)
     await channel.send(embed=embed)
 
+async def get_original_author(showcase_message: discord.Message):
+    split_url = showcase_message.embeds[0].url.split('/')
+    original_channel = showcase_message.guild.get_channel(int(split_url[-2]))
+    try:
+        original_message = await original_channel.fetch_message(int(split_url[-1]))
+        return original_message.author
+    except discord.DiscordException:
+        return None
 
 client.run(DISCORD_KEY)


### PR DESCRIPTION
In the showcase channel, `reaction.message.author` is always the bot, so the check would always fail and prevent users from removing their own showcased messages. This fix fetches the original/featured message to allow the comparison to be made against the original author.

**Notes:**

As of right now, every message in the showcase channel will have exactly one embed.
It can be retrieved with `message.embeds[0]` (such as on line 116).

The `embed.url` is set to `message.jump_url` (on line 106), so will always be of the form:
```https://discord.com/channels/<server_id>/<channel_id>/<message_id>```

We can split this string with `'/'` to access the IDs of the objects we need.

Index `-2` (the second-to-last item) gives us the original channel id.
Index `-1` (the very last item) gives us the original message id.

With this information, we can use `fetch_message` to get the original message (and its author).
<https://discordpy.readthedocs.io/en/stable/api.html#discord.TextChannel.fetch_message>

